### PR TITLE
Update test-python-publish.yml

### DIFF
--- a/.github/workflows/test-python-publish.yml
+++ b/.github/workflows/test-python-publish.yml
@@ -58,6 +58,4 @@ jobs:
         with:
           packages-dir: dist/
         env:
-          TWINE_USERNAME: ${{ secrets.TEST_PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_PASSWORD }}
           repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Remove the use of TWINE_USERNAME and TWINE_PASSWORD secrets from the test-python-publish.yml workflow.